### PR TITLE
Respect arrays for transformResponse options

### DIFF
--- a/src/sailsResource.js
+++ b/src/sailsResource.js
@@ -221,6 +221,13 @@
 						// converting single array to single item
 						if (!isArray(item) && isArray(data)) data = data[0];
 
+						if (isArray(action.transformResponse)) {
+							forEach(action.transformResponse, function(transformResponse) {
+								if (isFunction(transformResponse)) {
+									data = transformResponse(data);
+								}
+							})
+						}
 						if (isFunction(action.transformResponse)) data = action.transformResponse(data);
 						if (isFunction(delegate)) delegate(data);
 						deferred.resolve(item);


### PR DESCRIPTION
…just as built-in `$http` service does: https://code.angularjs.org/1.3.11/docs/api/ng/service/$http#transforming-requests-and-responses