### PR TITLE
allow the transformRequest to handle object or stringified json

### DIFF
--- a/src/sailsResource.js
+++ b/src/sailsResource.js
@@ -289,7 +289,8 @@
 				// prep data
 				var transformedData;
 				if (isFunction(action.transformRequest)) {
-					transformedData = JSON.parse(action.transformRequest(item));
+					var tmp = action.transformRequest(item);
+					transformedData = typeof tmp === 'object' ? tmp : JSON.parse(tmp);
 				}
 
 				// prevents prototype functions being sent


### PR DESCRIPTION
This makes makes is so the request isn't transformed from object to json to object again needlessly