### PR TITLE
Fix buildUrl() to exclude URL params from query string

### DIFF
--- a/spec/sailsResource.spec.js
+++ b/spec/sailsResource.spec.js
@@ -128,7 +128,7 @@ describe('sailsResource >', function () {
 
 		it('query works with custom url', function () {
 			var customItem = service.customRoute({customId: 'blah'});
-			expect(customItem.$retrieveUrl).toEqual('/widget/blah?customId=blah');
+			expect(customItem.$retrieveUrl).toEqual('/widget/blah');
 		});
 
 		it('works with custom params', function(){

--- a/src/sailsResource.js
+++ b/src/sailsResource.js
@@ -564,7 +564,7 @@
 		var queryParams = {};
 		angular.forEach(params, function(value, key) {
 			if (!urlParams[key]) {
-				queryParams = value;
+				queryParams[key] = value;
 			}
 		});
 		

--- a/src/sailsResource.js
+++ b/src/sailsResource.js
@@ -533,6 +533,8 @@
 	 */
 	function buildUrl(model, id, action, params, options) {
 		var url = [];
+		var urlParams = {};
+		
 		if (action && action.url) {
 			var actionUrl = action.url;
 
@@ -541,7 +543,12 @@
 			if (matches) {
 				forEach(matches, function (match) {
 					var paramName = match.replace(':', '');
-					actionUrl = actionUrl.replace(match, paramName == options.primaryKey ? id : params[paramName]);
+					if (paramName === options.primaryKey) {
+						actionUrl = actionUrl.replace(match, id);
+					} else {
+						urlParams[paramName] = true;
+						actionUrl = actionUrl.replace(match, params[paramName]);
+					}
 				});
 			}
 
@@ -553,7 +560,15 @@
 			url.push(model);
 			if (id) url.push('/' + id);
 		}
-		url.push(createQueryString(params, options));
+		
+		var queryParams = {};
+		angular.forEach(params, function(value, key) {
+			if (!urlParams[key]) {
+				queryParams = value;
+			}
+		});
+		
+		url.push(createQueryString(queryParams, options));
 		return url.join('');
 	}
 


### PR DESCRIPTION
```javascript
var Course = sailsResource("course", {
    findAllByStudent: {
        method: "GET",
        url: "/students/:student/courses"
    }
});

Course.findAllByStudent({student: 42});
```

Currently this call will build URL `/students/42/courses?student=42`. Though should (and will after this PR) build `/students/42/courses`.